### PR TITLE
Provide boot stuff, such as starting all services, and ordering

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"github.com/BurntSushi/toml"
+)
+
+type Config struct {
+	Groups         []string            `toml:"groups"`
+	GroupOverrides map[string][]string `toml:"group_overrides"`
+}
+
+func LoadConfig(fn string) (c Config, err error) {
+	_, err = toml.DecodeFile(fn, &c)
+
+	return
+}
+
+// HasOverride returns an optional 'override group' for a service.
+//
+// An override group is a local configuration option which allows the owner
+// of a system to override which group a service belongs to, even (effectively)
+// creating a brand new group and moving services into it.
+//
+// This allows users to tweak the order in which boot
+func (c Config) ReconcileOverride(svc, initialGroup string) (group string) {
+	var members []string
+
+	for group, members = range c.GroupOverrides {
+		if contains(members, svc) {
+			return
+		}
+	}
+
+	return initialGroup
+}
+
+func contains(ss []string, s string) bool {
+	for _, elem := range ss {
+		if elem == s {
+			return true
+		}
+	}
+
+	return false
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestConfig_ReconcileOverride(t *testing.T) {
+	defaultGroup := "testing"
+	overrideGroup := "my-group"
+	svc := "my-super-service"
+
+	for _, test := range []struct {
+		name   string
+		c      Config
+		expect string
+	}{
+		{"empty config returns inital group", Config{}, defaultGroup},
+		{"where no override exists, initial group returned", Config{GroupOverrides: map[string][]string{}}, defaultGroup},
+		{"where no relevant override exists, initial group returned", Config{GroupOverrides: map[string][]string{overrideGroup: []string{"another-service"}}}, defaultGroup},
+		{"override is returned", Config{GroupOverrides: map[string][]string{overrideGroup: []string{svc}}}, overrideGroup},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			grp := test.c.ReconcileOverride(svc, defaultGroup)
+			if test.expect != grp {
+				t.Errorf("expected %q, received %q", test.expect, grp)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -51,6 +51,11 @@ func Setup() *grpc.Server {
 		panic(err)
 	}
 
+	err = supervisor.StartAll()
+	if err != nil {
+		panic(err)
+	}
+
 	d := Dispatcher{supervisor, dispatcher.UnimplementedDispatcherServer{}}
 
 	grpcServer := grpc.NewServer(

--- a/service_config.go
+++ b/service_config.go
@@ -150,6 +150,9 @@ type ServiceConfig struct {
 
 func LoadServiceConfig(fn string) (s ServiceConfig, err error) {
 	_, err = toml.DecodeFile(fn, &s)
+	if err != nil {
+		return
+	}
 
 	switch s.Type {
 	case ServiceType_Service:

--- a/testdata/services/.config.toml
+++ b/testdata/services/.config.toml
@@ -1,0 +1,1 @@
+groups = ["system", "my-group", "etc"]


### PR DESCRIPTION
This change will:

1. Start services when `vinit` boots up
2. Provide a way of ordering which groups start when (and allow for custom groups to further control boot order)