### PR TITLE
Ensure correct boot process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ $(CERTS_DIR) $(GENERATED_DIR):
 	mkdir -p $@
 
 $(CERTS): | $(CERTS_DIR)
-	(cd $(CERTS_DIR) && ../scripts/gen-cert)
+	(cd $(CERTS_DIR) && $(CURDIR)/scripts/gen-cert)
 
 
 $(BINARY): $(GRPC_FILES) $(CERTS) *.go go.mod go.sum

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ $(CERTS): | $(CERTS_DIR)
 
 
 $(BINARY): $(GRPC_FILES) $(CERTS) *.go go.mod go.sum
-	CGO_ENABLED=0 go build -ldflags="-s -w" -trimpath -o $@
+	CGO_ENABLED=0 go build -ldflags="-s -w -X main.certDir=$(CERTS_DIR)" -trimpath -o $@
 
 
 # Because we need to do things like setuid on binaries, we need

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -23,6 +24,40 @@ func TestConfig_ReconcileOverride(t *testing.T) {
 			grp := test.c.ReconcileOverride(svc, defaultGroup)
 			if test.expect != grp {
 				t.Errorf("expected %q, received %q", test.expect, grp)
+			}
+		})
+	}
+}
+
+func TestConfig_StartupScript(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		fn          string
+		expectCmd   string
+		expectArgs  []string
+		expectError bool
+	}{
+		{"Empty startup script loads defaults", "testdata/successing/empty-startupscript.toml", defaultStartupScript.cmd, defaultStartupScript.args, false},
+		{"Undefined startup script loads defaults", "testdata/successing/undefined-startupscript.toml", defaultStartupScript.cmd, defaultStartupScript.args, false},
+		{"Only setting cmd means no args", "testdata/services/.config.toml", "/bin/date", []string(nil), false},
+		{"Setting cmd and args works correctly", "testdata/successing/full-startupscript.toml", "/sbin/agetty", []string{"tty1", "linux"}, false},
+		{"Dodgy/ unexpected error fails accordingly", "testdata/erroring/dodgy-startupscript.toml", "", []string(nil), true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			c, err := LoadConfig(test.fn)
+
+			if test.expectError && err == nil {
+				t.Errorf("expected error, received none")
+			} else if !test.expectError && err != nil {
+				t.Errorf("unexpected error %#v", err)
+			}
+
+			if test.expectCmd != c.StartupScript.cmd {
+				t.Errorf("expected %q, received %q", test.expectCmd, c.StartupScript.cmd)
+			}
+
+			if !reflect.DeepEqual(test.expectArgs, c.StartupScript.args) {
+				t.Errorf("expected %#v, received %#v", test.expectArgs, c.StartupScript.args)
 			}
 		})
 	}

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -27,7 +27,7 @@ func (d Dispatcher) Start(ctx context.Context, s *dispatcher.Service) (out *empt
 		return out, errNoService
 	}
 
-	return out, d.s.Start(s.Name)
+	return out, d.s.Start(s.Name, false)
 }
 
 func (d Dispatcher) Stop(ctx context.Context, s *dispatcher.Service) (out *emptypb.Empty, err error) {

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	srv := Setup()
 
-	lis, err := net.Listen("tcp", sockAddr)
+	lis, err := net.Listen("unix", sockAddr)
 	if err != nil {
 		sugar.Panic(err)
 	}

--- a/main.go
+++ b/main.go
@@ -43,6 +43,11 @@ func main() {
 
 	srv := Setup()
 
+	if os.Getpid() == 1 {
+		// try to delete sockAddr, if it exists
+		os.Remove(sockAddr)
+	}
+
 	lis, err := net.Listen("unix", sockAddr)
 	if err != nil {
 		sugar.Panic(err)

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"net"
 	"os"
+	"path/filepath"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
@@ -21,6 +22,7 @@ var (
 
 	sockAddr = "/run/vinit.sock"
 	svcDir   = envOrDefault("SVC_DIR", "/etc/vinit/services")
+	certDir  = "certs"
 )
 
 func init() {
@@ -96,7 +98,7 @@ func envOrDefault(envvar, def string) string {
 
 func loadTLSCredentials() (credentials.TransportCredentials, error) {
 	// Load server's certificate and private key
-	serverCert, err := tls.LoadX509KeyPair("certs/server-cert.pem", "certs/server-key.pem")
+	serverCert, err := tls.LoadX509KeyPair(filepath.Join(certDir, "server-cert.pem"), filepath.Join(certDir, "server-key.pem"))
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -44,8 +44,12 @@ func main() {
 	srv, supervisor := Setup()
 
 	if os.Getpid() == 1 {
-		// try to delete sockAddr, if it exists
-		os.Remove(sockAddr)
+		// try to delete sockAddr, if it exists.
+		//
+		// we don't care about the outcome of this; if the file doesn't
+		// exist then happy days, otherwise we'll get a more useful error
+		// when we try to listen anyway
+		os.Remove(sockAddr) //#nosec: G104
 	}
 
 	lis, err := net.Listen("unix", sockAddr)

--- a/main.go
+++ b/main.go
@@ -62,10 +62,7 @@ func Setup() *grpc.Server {
 		sugar.Panic(err)
 	}
 
-	err = supervisor.StartAll()
-	if err != nil {
-		panic(err)
-	}
+	supervisor.StartAll()
 
 	d := Dispatcher{supervisor, dispatcher.UnimplementedDispatcherServer{}}
 

--- a/main_test.go
+++ b/main_test.go
@@ -16,3 +16,30 @@ func TestSetup(t *testing.T) {
 
 	Setup()
 }
+
+func TestSetup_MissingSvcDir(t *testing.T) {
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Error("expected panic, received none")
+		}
+	}()
+
+	svcDir = "/tmp/this/dir/hopefully/doesnt/exist"
+
+	Setup()
+}
+
+func TestSetup_MissingCerts(t *testing.T) {
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Error("expected panic, received none")
+		}
+	}()
+
+	svcDir = "testdata/services"
+	certDir = "/tmp/this/dir/hopefully/doesnt/exist"
+
+	Setup()
+}

--- a/service.go
+++ b/service.go
@@ -81,7 +81,7 @@ func LoadService(dir string) (s *Service, err error) {
 	return
 }
 
-func (s *Service) Start() (err error) {
+func (s *Service) Start(wait bool) (err error) {
 	if s.isRunning() {
 		return fmt.Errorf("service is already running")
 	}
@@ -93,6 +93,13 @@ func (s *Service) Start() (err error) {
 	s.status.Running = true
 	s.status = ServiceStatus{
 		StartTime: time.Now(),
+	}
+
+	if s.Config.Type == ServiceType_Oneoff && wait {
+		s.status.Error = s.start()
+		s.status.Success = s.Config.Oneoff.Success(s.status.ExitStatus)
+
+		return s.status.Error
 	}
 
 	go func() {

--- a/service.go
+++ b/service.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -17,6 +18,9 @@ type ServiceStatus struct {
 	EndTime    time.Time
 	Success    bool
 	Error      error
+
+	// temporarily do stuff
+	stdout, stderr string
 }
 
 type Service struct {
@@ -153,6 +157,9 @@ func (s *Service) start() (err error) {
 	s.status.Running = false
 	s.status.EndTime = time.Now()
 	s.status.ExitStatus = s.proc.ProcessState.ExitCode()
+	s.status.stdout = s.proc.Stdout.(*bytes.Buffer).String()
+	s.status.stderr = s.proc.Stderr.(*bytes.Buffer).String()
+
 	s.proc = nil
 
 	return
@@ -198,13 +205,17 @@ func (s *Service) mkLogdir() error {
 }
 
 func (s *Service) streamStdout() (err error) {
-	s.proc.Stdout, err = os.OpenFile(filepath.Join(s.logdir, "stdout"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	//s.proc.Stdout, err = os.OpenFile(filepath.Join(s.logdir, "stdout"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+
+	s.proc.Stdout = new(bytes.Buffer)
 
 	return
 }
 
 func (s *Service) streamStderr() (err error) {
-	s.proc.Stderr, err = os.OpenFile(filepath.Join(s.logdir, "stderr"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	//s.proc.Stderr, err = os.OpenFile(filepath.Join(s.logdir, "stderr"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+
+	s.proc.Stderr = new(bytes.Buffer)
 
 	return
 }

--- a/service.go
+++ b/service.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -18,9 +17,6 @@ type ServiceStatus struct {
 	EndTime    time.Time
 	Success    bool
 	Error      error
-
-	// temporarily do stuff
-	stdout, stderr string
 }
 
 type Service struct {
@@ -134,14 +130,16 @@ func (s *Service) start() (err error) {
 	s.proc.SysProcAttr = &syscall.SysProcAttr{}
 	s.proc.SysProcAttr.Credential = &syscall.Credential{Uid: uint32(s.uid), Gid: uint32(s.gid)}
 
-	for _, f := range []func() error{
-		s.mkLogdir,
-		s.streamStdout,
-		s.streamStderr,
-	} {
-		err = f()
-		if err != nil {
-			return
+	if !s.Config.Command.IgnoreOutput {
+		for _, f := range []func() error{
+			s.mkLogdir,
+			s.streamStdout,
+			s.streamStderr,
+		} {
+			err = f()
+			if err != nil {
+				return
+			}
 		}
 	}
 
@@ -157,8 +155,6 @@ func (s *Service) start() (err error) {
 	s.status.Running = false
 	s.status.EndTime = time.Now()
 	s.status.ExitStatus = s.proc.ProcessState.ExitCode()
-	s.status.stdout = s.proc.Stdout.(*bytes.Buffer).String()
-	s.status.stderr = s.proc.Stderr.(*bytes.Buffer).String()
 
 	s.proc = nil
 
@@ -205,17 +201,13 @@ func (s *Service) mkLogdir() error {
 }
 
 func (s *Service) streamStdout() (err error) {
-	//s.proc.Stdout, err = os.OpenFile(filepath.Join(s.logdir, "stdout"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-
-	s.proc.Stdout = new(bytes.Buffer)
+	s.proc.Stdout, err = os.OpenFile(filepath.Join(s.logdir, "stdout"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 
 	return
 }
 
 func (s *Service) streamStderr() (err error) {
-	//s.proc.Stderr, err = os.OpenFile(filepath.Join(s.logdir, "stderr"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-
-	s.proc.Stderr = new(bytes.Buffer)
+	s.proc.Stderr, err = os.OpenFile(filepath.Join(s.logdir, "stderr"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 
 	return
 }

--- a/service_config.go
+++ b/service_config.go
@@ -135,7 +135,8 @@ func (o Oneoff) Success(exitCode int) bool {
 }
 
 type Command struct {
-	Args Args `toml:"args"`
+	Args         Args `toml:"args"`
+	IgnoreOutput bool `toml:"ignore_output"`
 }
 
 type ServiceConfig struct {

--- a/sudo_test.go
+++ b/sudo_test.go
@@ -26,7 +26,7 @@ func TestService_Run(t *testing.T) {
 		}
 	}()
 
-	err = s.Start()
+	err = s.Start(false)
 	if err != nil {
 		t.Errorf("unexpected error %#v", err)
 	}

--- a/supervisor.go
+++ b/supervisor.go
@@ -106,17 +106,13 @@ func (s *Supervisor) StartAll() (err error) {
 
 			err = s.Start(service, true)
 			if err != nil {
-				status, _ := s.Status(service)
-
-				sugar.Info(status.stdout)
-				sugar.Info(status.stderr)
-
-				sugar.Errorw(err.Error(),
+				sugar.Errorw("failed!",
 					"group", group,
 					"service", service,
+					"error", err.Error(),
 				)
 
-				return
+				continue
 			}
 
 			sugar.Infow("started!",

--- a/supervisor.go
+++ b/supervisor.go
@@ -140,7 +140,7 @@ func (s *Supervisor) RunShell() {
 	s.restartShell = true
 
 	for s.restartShell {
-		c := exec.Command(sc.cmd, sc.args...)
+		c := exec.Command(sc.cmd, sc.args...) //#nosec: G204
 		c.Env = os.Environ()
 		c.Dir = "/"
 

--- a/supervisor.go
+++ b/supervisor.go
@@ -111,7 +111,7 @@ func (s *Supervisor) StartAll() (err error) {
 	}
 
 	// fuck it, stop and wait
-	time.Sleep(time.Second)
+	time.Sleep(time.Second * 10)
 
 	return
 }

--- a/supervisor.go
+++ b/supervisor.go
@@ -52,6 +52,8 @@ func (s *Supervisor) LoadConfigs() (err error) {
 
 		svc, err = LoadService(filepath.Join(s.dir, entry.Name()))
 		if err != nil {
+			log.Println(entry.Name())
+
 			return
 		}
 

--- a/supervisor.go
+++ b/supervisor.go
@@ -19,6 +19,7 @@ type Supervisor struct {
 	dir            string
 	groupsServices map[string][]string
 	services       map[string]*Service
+	restartShell   bool
 }
 
 func New(dir string) (s *Supervisor, err error) {
@@ -132,7 +133,13 @@ func (s *Supervisor) StartAll() {
 func (s *Supervisor) RunShell() {
 	sc := s.Config.StartupScript
 
-	for {
+	// Keep restarting shell if it crashes
+	//
+	// This is used during shutdown, for instance,
+	// to stop the inital shell constantly restarting
+	s.restartShell = true
+
+	for s.restartShell {
 		c := exec.Command(sc.cmd, sc.args...)
 		c.Env = os.Environ()
 		c.Dir = "/"

--- a/supervisor.go
+++ b/supervisor.go
@@ -87,7 +87,9 @@ func (s *Supervisor) Reload(name string) error {
 	return s.services[name].Reload()
 }
 
-func (s *Supervisor) StartAll() (err error) {
+func (s *Supervisor) StartAll() {
+	var err error
+
 	for _, group := range s.Config.Groups {
 		services, ok := s.groupsServices[group]
 		if !ok {
@@ -122,8 +124,6 @@ func (s *Supervisor) StartAll() (err error) {
 
 		}
 	}
-
-	return
 }
 
 func (s *Supervisor) StopAll() (err error) {

--- a/supervisor.go
+++ b/supervisor.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strings"
+	"time"
 )
 
 var (
@@ -123,6 +126,31 @@ func (s *Supervisor) StartAll() {
 			)
 
 		}
+	}
+}
+
+func (s *Supervisor) RunShell() {
+	sc := s.Config.StartupScript
+
+	for {
+		c := exec.Command(sc.cmd, sc.args...)
+		c.Env = os.Environ()
+		c.Dir = "/"
+
+		c.Stdin = os.Stdin
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+
+		err := c.Run()
+		if err != nil {
+			sugar.Errorw("shell restarting",
+				"cmd", sc.cmd,
+				"args", strings.Join(sc.args, " "),
+				"error", err.Error(),
+			)
+		}
+
+		time.Sleep(time.Second)
 	}
 }
 

--- a/supervisor.go
+++ b/supervisor.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"time"
 )
 
 var (
@@ -100,12 +101,17 @@ func (s *Supervisor) StartAll() (err error) {
 		}
 
 		for _, service := range services {
+			log.Printf("[%s] %s - starting", time.Now(), service)
+
 			err = s.Start(service)
 			if err != nil {
 				return
 			}
 		}
 	}
+
+	// fuck it, stop and wait
+	time.Sleep(time.Second)
 
 	return
 }

--- a/supervisor.go
+++ b/supervisor.go
@@ -106,6 +106,11 @@ func (s *Supervisor) StartAll() (err error) {
 
 			err = s.Start(service, true)
 			if err != nil {
+				status, _ := s.Status(service)
+
+				sugar.Info(status.stdout)
+				sugar.Info(status.stderr)
+
 				sugar.Errorw(err.Error(),
 					"group", group,
 					"service", service,
@@ -113,6 +118,12 @@ func (s *Supervisor) StartAll() (err error) {
 
 				return
 			}
+
+			sugar.Infow("started!",
+				"group", group,
+				"service", service,
+			)
+
 		}
 	}
 

--- a/supervisor_test.go
+++ b/supervisor_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestNew(t *testing.T) {
@@ -21,4 +22,25 @@ func TestNew(t *testing.T) {
 			t.Errorf("expected\n%#v\n\nreceived%#v", expect, got)
 		}
 	})
+}
+
+func TestSupervisor_RunShell_RunsWithoutPanic(t *testing.T) {
+	s, err := New("testdata/services")
+	if err != nil {
+		t.Errorf("unexpected error %#v", err)
+	}
+
+	defer func() {
+		err := recover()
+		if err != nil {
+			t.Errorf("unexpected error: %#v", err)
+		}
+	}()
+
+	go s.RunShell()
+
+	// give the shell time to do stuff
+	time.Sleep(time.Millisecond * 100)
+
+	s.restartShell = false
 }

--- a/testdata/erroring/dodgy-startupscript.toml
+++ b/testdata/erroring/dodgy-startupscript.toml
@@ -1,0 +1,1 @@
+startup_script = '"'

--- a/testdata/services/.config.toml
+++ b/testdata/services/.config.toml
@@ -1,1 +1,3 @@
 groups = ["system", "my-group", "etc"]
+
+startup_script = "/bin/date"

--- a/testdata/successing/empty-startupscript.toml
+++ b/testdata/successing/empty-startupscript.toml
@@ -1,0 +1,2 @@
+groups = ["system"]
+startup_script = ""

--- a/testdata/successing/full-startupscript.toml
+++ b/testdata/successing/full-startupscript.toml
@@ -1,0 +1,2 @@
+groups = ["system"]
+startup_script = "/sbin/agetty tty1 linux"

--- a/testdata/successing/undefined-startupscript.toml
+++ b/testdata/successing/undefined-startupscript.toml
@@ -1,0 +1,1 @@
+groups = ["system"]


### PR DESCRIPTION
This pr:

1. Makes sure a shell is started for users to use
2. Removes panics, replacing with sensible logging
3. Uses tls for init calls (no real reason, I guess, just why not?)
4. Simplifies oneoff logic
5. Allows users to 'wait' for a oneoff to complete
6. Deletes old sockets- previously if `vinit` crashed before clean up then it'd never start again

This is tested, and works quite nicely- certainly nicely enough to move on