### PR TITLE
Allow for environment variable overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ BUILT_ON ?= $(shell date --rfc-3339=seconds | sed 's/ /T/')
 BUILT_BY ?= $(shell whoami)
 BUILD_REF ?= $(shell git symbolic-ref -q --short HEAD || git describe --tags --exact-match)
 
+.PHONY: default
 default: $(GRPC_FILES) $(CERTS) $(BINARY) $(CLIENT_BINARY)
 
 $(SERVER_DIR) $(CERTS_DIR) $(GENERATED_DIR) $(PKG_DIR):

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ A service directory looks like:
 ├  .config.toml
 ├  bin
 ├  environment
+├  environment_overrides
 ├  logs
 │   ├ stderr
 │   └ stdout
@@ -58,6 +59,7 @@ Where:
 1. `.config.toml` is the service configuration, including arguments to pass to `bin`, setuid configuration, and grouping information. This is described in depth below.
 1. `bin` is the script/ binary/ application to run (which is usually a symlink; see: [20-dropbear/bin](https://github.com/vinyl-linux/vin-packages-stable/blob/main/dropbear/2020.81/20-dropbear/bin), which points to `/usr/sbin/dropbear`)
 1. `environment` is a file containing `KEY=value` pairs, and is used to set the environment in which `bin` runs
+1. `environment_overrides` is a file much the same as `environment`, but with system specific vars; in `vinit` we assume that `environment` is owned by the package maintainer, and as such can be clobbered by upgrades, whereas `environment_overrides` (which is loaded after `environment` and, as such, overrides vars in that file) is owned by the user and can be used to tune things better
 1. `logs` is a directory containing a file for both `stdout` and `stderr` (this directory/ these files will be created if they don't exist, with each file being appended to- `vinit` doesn't handle log rotation)
 1. `wd` is a directory (which is also often a symlink; see [99-vind/wd](https://github.com/vinyl-linux/vin-packages-stable/blob/main/vin/0.7.0/99-vind/wd), which points to `/etc/vinyl`
 

--- a/service.go
+++ b/service.go
@@ -56,6 +56,20 @@ func LoadService(dir string) (s *Service, err error) {
 		return
 	}
 
+	overridesFn := filepath.Join(dir, "environment_overrides")
+	if _, err = os.Stat(overridesFn); err == nil {
+		var overrides EnvVars
+
+		overrides, err = LoadEnvVars(overridesFn)
+		if err != nil {
+			return
+		}
+
+		s.Env = append(s.Env, overrides...)
+	}
+
+	err = nil
+
 	uid, err := s.Config.User.Uid()
 	if err != nil {
 		return

--- a/service_test.go
+++ b/service_test.go
@@ -28,7 +28,6 @@ func TestLoadService(t *testing.T) {
 			} else if !test.expectError && err != nil {
 				t.Errorf("unexpected error %#v", err)
 			}
-
 		})
 	}
 }

--- a/testdata/services/00-app/environment_overrides
+++ b/testdata/services/00-app/environment_overrides
@@ -1,0 +1,1 @@
+HELLO=world


### PR DESCRIPTION
While introducing the vin-packages-alpine project, it became obvious that configuring vinyl by a single environment file was going to risk having upgrades pull in configuration changes that I just dont need on every system.

I thought about moving more stuff from the vinyl env into the config file, but that gave me the same problem- upgrades will clobber stuff.

So, to avoid having to solve that problem just yet, I decided that vinit services could have two env files; one that package maintainers own (via vinit), and one that system users can use to provide their own tunings.