### PR TITLE
Don't drop to shell if service configs are bad on boot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
         go-version: 1.17
 
     - name: Build
-      run: make
+      run: |
+        make -o dispatcher/dispatcher.pb.go -o dispatcher/dispatcher_grpc.pb.go
 
     - name: Test
       run: |

--- a/main.go
+++ b/main.go
@@ -70,7 +70,15 @@ func Setup() (grpcServer *grpc.Server, err error) {
 
 	supervisor, err = New(svcDir)
 	if err != nil {
-		return
+		if _, ok := err.(ConfigParseError); !ok {
+			return
+		}
+
+		sugar.Warnw("could not load all configs",
+			"error", err.Error(),
+		)
+
+		err = nil
 	}
 
 	tlsCredentials, err := loadTLSCredentials()

--- a/main_test.go
+++ b/main_test.go
@@ -13,6 +13,15 @@ func TestSetup(t *testing.T) {
 	}
 }
 
+func TestSetup_DodgyServicesJustWarns(t *testing.T) {
+	svcDir = "testdata/mixed-status-services"
+
+	_, err := Setup()
+	if err != nil {
+		t.Errorf("unexpected error %#v", err)
+	}
+}
+
 func TestSetup_MissingSvcDir(t *testing.T) {
 	svcDir = "/tmp/this/dir/hopefully/doesnt/exist"
 

--- a/supervisor.go
+++ b/supervisor.go
@@ -66,7 +66,7 @@ func (s *Supervisor) LoadConfigs() (err error) {
 	}
 
 	var svc *Service
-	cpe := new(ConfigParseError)
+	cpe := ConfigParseError{}
 
 	for _, entry := range entries {
 		if !entry.IsDir() {


### PR DESCRIPTION
Rather than dropping to shell if a config is wrong, log it and continue as best we can.

This allows users to login later and fix anything that needs fixing