### PR TITLE
Ensure boot handles broken configs better

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ $(CLIENT_BINARY): client client/*.go client/**/*.go
 # This avoids having to redownload dependencies and having to configure
 # toolchains/ go env vars
 $(TEST_BINARY): $(GRPC_FILES) $(CERTS) *.go go.mod go.sum
-	-go test -covermode=count -o $@ -tags sudo > /dev/null
+	go test -covermode=count -c -o $@ -tags sudo > /dev/null
 
 .PHONY: test
 test: $(TEST_BINARY)

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	errNoService       = status.Error(codes.InvalidArgument, "missing service name")
-	errServiceNotExist = status.Error(codes.InvalidArgument, "service does not exist")
+	errNoService        = status.Error(codes.InvalidArgument, "missing service name")
+	errServiceNotExist  = status.Error(codes.InvalidArgument, "service does not exist")
+	errServiceDodgyConf = status.Error(codes.FailedPrecondition, "service config is incorrect")
 )
 
 type Dispatcher struct {

--- a/service.go
+++ b/service.go
@@ -42,16 +42,13 @@ type Service struct {
 	// prior to restarting
 	desiredRunning bool
 
-	// isDirty is set to true if a call to Supervisor.LoadConfigs
+	// loadError is set if a call to Supervisor.LoadConfigs
 	// fails and so new config hasn't been picked up.
 	//
 	// we can assume that this means there's a new config that doesn't
 	// look right, since the existence of this service means it must
 	// have been right first time.
-	//
-	// but, in any case, isDirty is a flag that means 'Something went
-	// wrong parsing this service config, go check the logs'
-	isDirty bool
+	loadError string
 }
 
 func LoadService(dir string) (s *Service, err error) {

--- a/supervisor_test.go
+++ b/supervisor_test.go
@@ -6,14 +6,12 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	s, err := New("testdata/services")
-	if err != nil {
-		t.Errorf("unexpected error %#v", err)
-	}
+	s, _ := New("testdata/services")
 
 	t.Run("groups and service mappings are correct", func(t *testing.T) {
 		got := s.groupsServices
 		expect := map[string][]string{
+			"":       []string{"broken"},
 			"system": []string{"app", "app-cronjob", "app-oneoff"},
 		}
 

--- a/testdata/services/01-broken/.config.toml
+++ b/testdata/services/01-broken/.config.toml
@@ -1,0 +1,15 @@
+# 'App' service config file
+#
+
+type = "service"
+reload_signal = "nuffin"
+
+[user]
+user = "jspc"
+group = "jspc"
+
+[grouping]
+name = "system"
+
+[command]
+args = "-a -b -c 100"

--- a/testdata/services/01-broken/bin
+++ b/testdata/services/01-broken/bin
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+while true; do
+	date
+	sleep 1s
+done

--- a/testdata/services/01-broken/environment
+++ b/testdata/services/01-broken/environment
@@ -1,0 +1,1 @@
+PATH=/bin:/sbin

--- a/testdata/services/01-broken/environment_overrides
+++ b/testdata/services/01-broken/environment_overrides
@@ -1,0 +1,1 @@
+HELLO=world


### PR DESCRIPTION
Previously, booting up with broken vinits would cause nothing to start. We would have a shell, but nothing else. This seems wrong- in fact we want all services that _can_ start to start, and to be able to see in the logs what was broken.

This change will store a field in a Service signifying what the error was, and will move that service to an empty group.

This will allow us to limp a system up as best we can, allowing logins and stuff