### PR TITLE
Only run services once, erroring if they exit at all

### DIFF
--- a/service_test.go
+++ b/service_test.go
@@ -21,7 +21,7 @@ func TestLoadService(t *testing.T) {
 		{"happy path", "testdata/services/00-app", false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := LoadService(test.dir)
+			_, err := LoadService("", test.dir)
 
 			if test.expectError && err == nil {
 				t.Errorf("expected error, received none")
@@ -40,7 +40,7 @@ func TestService_Start_UnableToWriteLogs(t *testing.T) {
 		}
 	}()
 
-	s, err := LoadService("testdata/erroring/logs-unwritable")
+	s, err := LoadService("", "testdata/erroring/logs-unwritable")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func TestService_Start_UnableToCreateLogs(t *testing.T) {
 		}
 	}()
 
-	s, err := LoadService("testdata/erroring/logdir-uncreatable")
+	s, err := LoadService("", "testdata/erroring/logdir-uncreatable")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sudo_test.go
+++ b/sudo_test.go
@@ -14,7 +14,7 @@ import (
 func TestService_Run(t *testing.T) {
 	d, _ := os.Getwd()
 
-	s, err := LoadService(filepath.Join(d, "testdata/services/00-app-oneoff"))
+	s, err := LoadService("app-oneoff", filepath.Join(d, "testdata/services/00-app-oneoff"))
 	if err != nil {
 		t.Errorf("unexpected error %#v", err)
 	}

--- a/supervisor.go
+++ b/supervisor.go
@@ -73,13 +73,12 @@ func (s *Supervisor) LoadConfigs() (err error) {
 			continue
 		}
 
-		svc, err = LoadService(filepath.Join(s.dir, entry.Name()))
+		name := serviceName(entry.Name())
+		svc, err = LoadService(name, filepath.Join(s.dir, entry.Name()))
 		if err != nil {
 			cpe.Append(entry.Name(), err)
 			svc.loadError = err.Error()
 		}
-
-		name := serviceName(entry.Name())
 
 		var groupName string
 		if svc.loadError == "" {


### PR DESCRIPTION
See: https://github.com/vinyl-linux/vinit/issues/18

For now, possibly forever, let's just exit if a service dies (rather than trying to restart it), and let's also make sure proc is set when setting stdout/stderr (in case the process has already died somehow)